### PR TITLE
Fix noise model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+### Added
+- Electron multiplication (EM) gain and camera baseline parameters.
+
+### Fixed
+- The camera noise model was improperly accounting for electron
+  multiplication noise. This is now fixed and encompasses both EMCCD's
+  (by setting the EM gain to a non-zero value) and sCMOS (by setting
+  the EM gain to zero.)
+	
 ## [v0.2.0]
 Contains [ALICA v0.2.1]
 

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,49 @@
+with import <nixpkgs> {};
+
+(
+  let
+
+  javalang = pkgs.python35Packages.buildPythonPackage rec {
+
+      name = "javalang-${version}";
+      version = "0.11.0";
+
+      src = pkgs.fetchurl {
+        url = "https://github.com/c2nes/javalang/archive/javalang-0.11.0.tar.gz";
+	sha256 = "99817f218e29b9004236f59953a9540af34e140a9fcaeabefa4f44ebe0fa22dd";
+      };
+
+      buildInputs = [ pkgs.python35Packages.six ];
+
+      meta = {
+        homepage = "https://github.com/c2nes/javalang";
+        description = " Pure Python Java parser and tools";
+      };
+    };
+    
+    javasphinx = pkgs.python35Packages.buildPythonPackage rec {
+
+      name = "javasphinx-${version}";
+      version = "0.9.15";
+
+      src = pkgs.fetchurl {
+        url = "https://github.com/bronto/javasphinx/archive/javasphinx-0.9.15.tar.gz";
+	sha256 = "3af6e85a5d0502ee7a6e292a0a23978ba1f25bbc3e6c197a455e2fa4598cb406";
+      };
+
+      buildInputs = [ javalang
+      		      pkgs.python35Packages.lxml
+                      pkgs.python35Packages.beautifulsoup4
+	       	      pkgs.python35Packages.future
+		      pkgs.python35Packages.docutils
+		      pkgs.python35Packages.sphinx];
+
+      meta = {
+        homepage = "https://github.com/bronto/javasphinx";
+	description = "Sphinx extension for documenting Java projects";
+      };
+    
+    };
+
+  in pkgs.python35.withPackages (ps: [ ps.sphinx pkgs.netbeans javalang javasphinx ])
+).env

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
@@ -109,66 +109,80 @@
                               <Component id="label7" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label8" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label9" alignment="0" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                          <EmptySpace min="-2" pref="31" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_adu_per_electron" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label20" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_quantum_eff" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label19" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_dark_current" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label18" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_readout_noise" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label17" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_FPS" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label16" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_resY" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label15" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" alignment="0" attributes="0">
+                                  <Component id="cam_resX" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label14" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                          </Group>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace min="-2" pref="86" max="-2" attributes="0"/>
+                          <Component id="label26" min="-2" pref="111" max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="label10" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label11" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label12" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label13" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label25" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
-                              <Group type="102" attributes="0">
+                              <Group type="102" alignment="0" attributes="0">
                                   <EmptySpace min="-2" pref="21" max="-2" attributes="0"/>
                                   <Group type="103" groupAlignment="0" attributes="0">
-                                      <Group type="102" attributes="0">
+                                      <Group type="102" alignment="0" attributes="0">
                                           <Component id="cam_wavelength" min="-2" pref="45" max="-2" attributes="0"/>
                                           <EmptySpace max="-2" attributes="0"/>
                                           <Component id="label23" min="-2" max="-2" attributes="0"/>
                                       </Group>
-                                      <Group type="102" attributes="0">
+                                      <Group type="102" alignment="0" attributes="0">
                                           <Component id="cam_NA" min="-2" pref="45" max="-2" attributes="0"/>
                                           <EmptySpace max="-2" attributes="0"/>
                                           <Component id="label22" min="-2" max="-2" attributes="0"/>
                                       </Group>
-                                      <Group type="102" attributes="0">
+                                      <Group type="102" alignment="0" attributes="0">
                                           <Component id="cam_px_size" min="-2" pref="45" max="-2" attributes="0"/>
                                           <EmptySpace max="-2" attributes="0"/>
                                           <Component id="label21" min="-2" max="-2" attributes="0"/>
                                       </Group>
-                                      <Group type="102" attributes="0">
-                                          <Component id="cam_gain" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label20" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" attributes="0">
-                                          <Component id="cam_quantum_eff" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label19" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" attributes="0">
-                                          <Component id="cam_dark_current" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label18" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" attributes="0">
-                                          <Component id="cam_readout_noise" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label17" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" attributes="0">
-                                          <Component id="cam_FPS" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label16" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" attributes="0">
-                                          <Component id="cam_resY" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label15" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" alignment="0" attributes="0">
-                                          <Component id="cam_resX" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label14" min="-2" max="-2" attributes="0"/>
-                                      </Group>
+                                      <Component id="cam_em_gain" alignment="0" min="-2" pref="45" max="-2" attributes="0"/>
                                   </Group>
                               </Group>
                               <Group type="102" alignment="0" attributes="0">
@@ -178,10 +192,6 @@
                                   <Component id="label24" min="-2" max="-2" attributes="0"/>
                               </Group>
                           </Group>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <EmptySpace min="-2" pref="86" max="-2" attributes="0"/>
-                          <Component id="label26" min="-2" pref="111" max="-2" attributes="0"/>
                       </Group>
                   </Group>
                   <EmptySpace max="32767" attributes="0"/>
@@ -206,7 +216,70 @@
                           <Component id="label8" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="label9" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="103" alignment="0" groupAlignment="1" attributes="0">
+                          <Group type="102" attributes="0">
+                              <Group type="103" groupAlignment="1" attributes="0">
+                                  <Group type="102" attributes="0">
+                                      <Group type="103" groupAlignment="1" attributes="0">
+                                          <Group type="102" attributes="0">
+                                              <Group type="103" groupAlignment="1" attributes="0">
+                                                  <Group type="102" attributes="0">
+                                                      <Group type="103" groupAlignment="1" attributes="0">
+                                                          <Group type="102" attributes="0">
+                                                              <Component id="label26" min="-2" max="-2" attributes="0"/>
+                                                              <EmptySpace max="-2" attributes="0"/>
+                                                              <Group type="103" groupAlignment="1" attributes="0">
+                                                                  <Group type="102" attributes="0">
+                                                                      <Group type="103" groupAlignment="1" attributes="0">
+                                                                          <Component id="label14" min="-2" max="-2" attributes="0"/>
+                                                                          <Component id="cam_resX" min="-2" max="-2" attributes="0"/>
+                                                                          <Component id="label2" alignment="1" min="-2" max="-2" attributes="0"/>
+                                                                      </Group>
+                                                                      <EmptySpace max="-2" attributes="0"/>
+                                                                      <Component id="label15" min="-2" max="-2" attributes="0"/>
+                                                                  </Group>
+                                                                  <Component id="cam_resY" min="-2" max="-2" attributes="0"/>
+                                                              </Group>
+                                                              <EmptySpace max="-2" attributes="0"/>
+                                                              <Component id="label16" min="-2" max="-2" attributes="0"/>
+                                                          </Group>
+                                                          <Component id="cam_FPS" min="-2" max="-2" attributes="0"/>
+                                                      </Group>
+                                                      <EmptySpace max="-2" attributes="0"/>
+                                                      <Component id="label17" min="-2" max="-2" attributes="0"/>
+                                                  </Group>
+                                                  <Component id="cam_readout_noise" min="-2" max="-2" attributes="0"/>
+                                              </Group>
+                                              <EmptySpace max="-2" attributes="0"/>
+                                              <Component id="label18" min="-2" max="-2" attributes="0"/>
+                                          </Group>
+                                          <Component id="cam_dark_current" min="-2" max="-2" attributes="0"/>
+                                      </Group>
+                                      <EmptySpace max="-2" attributes="0"/>
+                                      <Component id="label19" min="-2" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Component id="cam_quantum_eff" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <EmptySpace max="-2" attributes="0"/>
+                              <Component id="label20" min="-2" max="-2" attributes="0"/>
+                          </Group>
+                          <Component id="cam_adu_per_electron" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" attributes="0">
+                          <Component id="cam_em_gain" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace pref="12" max="32767" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="1" attributes="0">
+                          <EmptySpace max="32767" attributes="0"/>
+                          <Component id="label25" min="-2" max="-2" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <Group type="103" groupAlignment="1" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace min="7" pref="7" max="-2" attributes="0"/>
                           <Component id="label10" min="-2" max="-2" attributes="0"/>
                           <EmptySpace max="-2" attributes="0"/>
                           <Component id="label11" min="-2" max="-2" attributes="0"/>
@@ -217,63 +290,11 @@
                       </Group>
                       <Group type="102" alignment="0" attributes="0">
                           <Group type="103" groupAlignment="1" attributes="0">
-                              <Group type="102" attributes="0">
+                              <Group type="102" alignment="1" attributes="0">
                                   <Group type="103" groupAlignment="1" attributes="0">
-                                      <Group type="102" attributes="0">
+                                      <Group type="102" alignment="1" attributes="0">
                                           <Group type="103" groupAlignment="1" attributes="0">
-                                              <Group type="102" attributes="0">
-                                                  <Group type="103" groupAlignment="1" attributes="0">
-                                                      <Group type="102" attributes="0">
-                                                          <Group type="103" groupAlignment="1" attributes="0">
-                                                              <Group type="102" attributes="0">
-                                                                  <Group type="103" groupAlignment="1" attributes="0">
-                                                                      <Group type="102" attributes="0">
-                                                                          <Group type="103" groupAlignment="1" attributes="0">
-                                                                              <Group type="102" attributes="0">
-                                                                                  <Group type="103" groupAlignment="1" attributes="0">
-                                                                                      <Group type="102" attributes="0">
-                                                                                          <Component id="label26" min="-2" max="-2" attributes="0"/>
-                                                                                          <EmptySpace max="-2" attributes="0"/>
-                                                                                          <Group type="103" groupAlignment="1" attributes="0">
-                                                                                              <Group type="102" attributes="0">
-                                                                                                  <Group type="103" groupAlignment="1" attributes="0">
-                                                                                                      <Component id="label14" min="-2" max="-2" attributes="0"/>
-                                                                                                      <Component id="cam_resX" min="-2" max="-2" attributes="0"/>
-                                                                                                      <Component id="label2" alignment="1" min="-2" max="-2" attributes="0"/>
-                                                                                                  </Group>
-                                                                                                  <EmptySpace max="-2" attributes="0"/>
-                                                                                                  <Component id="label15" min="-2" max="-2" attributes="0"/>
-                                                                                              </Group>
-                                                                                              <Component id="cam_resY" min="-2" max="-2" attributes="0"/>
-                                                                                          </Group>
-                                                                                          <EmptySpace max="-2" attributes="0"/>
-                                                                                          <Component id="label16" min="-2" max="-2" attributes="0"/>
-                                                                                      </Group>
-                                                                                      <Component id="cam_FPS" min="-2" max="-2" attributes="0"/>
-                                                                                  </Group>
-                                                                                  <EmptySpace max="-2" attributes="0"/>
-                                                                                  <Component id="label17" min="-2" max="-2" attributes="0"/>
-                                                                              </Group>
-                                                                              <Component id="cam_readout_noise" min="-2" max="-2" attributes="0"/>
-                                                                          </Group>
-                                                                          <EmptySpace max="-2" attributes="0"/>
-                                                                          <Component id="label18" min="-2" max="-2" attributes="0"/>
-                                                                      </Group>
-                                                                      <Component id="cam_dark_current" min="-2" max="-2" attributes="0"/>
-                                                                  </Group>
-                                                                  <EmptySpace max="-2" attributes="0"/>
-                                                                  <Component id="label19" min="-2" max="-2" attributes="0"/>
-                                                              </Group>
-                                                              <Component id="cam_quantum_eff" min="-2" max="-2" attributes="0"/>
-                                                          </Group>
-                                                          <EmptySpace max="-2" attributes="0"/>
-                                                          <Component id="label20" min="-2" max="-2" attributes="0"/>
-                                                      </Group>
-                                                      <Component id="cam_gain" min="-2" max="-2" attributes="0"/>
-                                                  </Group>
-                                                  <EmptySpace max="-2" attributes="0"/>
-                                                  <Component id="label21" min="-2" max="-2" attributes="0"/>
-                                              </Group>
+                                              <Component id="label21" alignment="1" min="-2" max="-2" attributes="0"/>
                                               <Component id="cam_px_size" min="-2" max="-2" attributes="0"/>
                                           </Group>
                                           <EmptySpace max="-2" attributes="0"/>
@@ -293,7 +314,7 @@
                           </Group>
                       </Group>
                   </Group>
-                  <EmptySpace max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -336,8 +357,11 @@
         </Component>
         <Component class="java.awt.Label" name="label9">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Gain:"/>
+            <Property name="text" type="java.lang.String" value="ADU per electron:"/>
           </Properties>
+          <AccessibilityProperties>
+            <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="ADU per electron"/>
+          </AccessibilityProperties>
         </Component>
         <Component class="java.awt.Label" name="label10">
           <Properties>
@@ -425,7 +449,7 @@
             <Property name="text" type="java.lang.String" value="0.8"/>
           </Properties>
         </Component>
-        <Component class="java.awt.TextField" name="cam_gain">
+        <Component class="java.awt.TextField" name="cam_adu_per_electron">
           <Properties>
             <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
               <Color id="Text Cursor"/>
@@ -435,6 +459,9 @@
             </Property>
             <Property name="text" type="java.lang.String" value="6"/>
           </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cam_adu_per_electronActionPerformed"/>
+          </Events>
         </Component>
         <Component class="java.awt.TextField" name="cam_px_size">
           <Properties>
@@ -533,6 +560,25 @@
         <Component class="java.awt.Label" name="label24">
           <Properties>
             <Property name="text" type="java.lang.String" value="-"/>
+          </Properties>
+        </Component>
+        <Component class="java.awt.TextField" name="cam_em_gain">
+          <Properties>
+            <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+              <Color id="Text Cursor"/>
+            </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[120, 20]"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="100"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cam_em_gainActionPerformed"/>
+          </Events>
+        </Component>
+        <Component class="java.awt.Label" name="label25">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="EM gain:"/>
           </Properties>
         </Component>
       </SubComponents>
@@ -943,8 +989,8 @@
         </Component>
         <Component class="java.awt.Button" name="emitter_choosefile_button">
           <Properties>
-            <Property name="enabled" type="boolean" value="false"/>
             <Property name="label" type="java.lang.String" value="Choose file..."/>
+            <Property name="enabled" type="boolean" value="false"/>
           </Properties>
           <Events>
             <EventHandler event="mouseClicked" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="emitter_choosefile_buttonMouseClicked"/>
@@ -1039,8 +1085,8 @@
         </Component>
         <Component class="java.awt.TextField" name="goldbead_number">
           <Properties>
-            <Property name="enabled" type="boolean" value="false"/>
             <Property name="text" type="java.lang.String" value="5"/>
+            <Property name="enabled" type="boolean" value="false"/>
           </Properties>
         </Component>
         <Component class="java.awt.Checkbox" name="checkbox_background">
@@ -1053,8 +1099,8 @@
         </Component>
         <Component class="java.awt.Button" name="background_choosefile_button">
           <Properties>
-            <Property name="enabled" type="boolean" value="false"/>
             <Property name="label" type="java.lang.String" value="Choose file..."/>
+            <Property name="enabled" type="boolean" value="false"/>
           </Properties>
           <Events>
             <EventHandler event="mouseClicked" listener="java.awt.event.MouseListener" parameters="java.awt.event.MouseEvent" handler="background_choosefile_buttonMouseClicked"/>
@@ -1072,8 +1118,8 @@
         </Component>
         <Component class="java.awt.TextField" name="goldbead_signal">
           <Properties>
-            <Property name="enabled" type="boolean" value="false"/>
             <Property name="text" type="java.lang.String" value="3000"/>
+            <Property name="enabled" type="boolean" value="false"/>
           </Properties>
         </Component>
       </SubComponents>

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
@@ -155,12 +155,18 @@
                       </Group>
                       <Group type="102" alignment="0" attributes="0">
                           <EmptySpace max="-2" attributes="0"/>
+                          <Component id="label25" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="-2" pref="108" max="-2" attributes="0"/>
+                          <Component id="cam_em_gain" min="-2" pref="45" max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="label10" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label11" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label12" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label13" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="label25" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label49" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
@@ -182,7 +188,7 @@
                                           <EmptySpace max="-2" attributes="0"/>
                                           <Component id="label21" min="-2" max="-2" attributes="0"/>
                                       </Group>
-                                      <Component id="cam_em_gain" alignment="0" min="-2" pref="45" max="-2" attributes="0"/>
+                                      <Component id="cam_baseline" alignment="0" min="-2" pref="45" max="-2" attributes="0"/>
                                   </Group>
                               </Group>
                               <Group type="102" alignment="0" attributes="0">
@@ -276,6 +282,11 @@
                           <EmptySpace max="32767" attributes="0"/>
                           <Component id="label25" min="-2" max="-2" attributes="0"/>
                       </Group>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="cam_baseline" min="-2" max="-2" attributes="0"/>
+                      <Component id="label49" alignment="1" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <Group type="103" groupAlignment="1" attributes="0">
                       <Group type="102" alignment="0" attributes="0">
@@ -570,6 +581,7 @@
             <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
               <Dimension value="[120, 20]"/>
             </Property>
+            <Property name="name" type="java.lang.String" value="" noResource="true"/>
             <Property name="text" type="java.lang.String" value="100"/>
           </Properties>
           <Events>
@@ -579,6 +591,28 @@
         <Component class="java.awt.Label" name="label25">
           <Properties>
             <Property name="text" type="java.lang.String" value="EM gain:"/>
+          </Properties>
+        </Component>
+        <Component class="java.awt.TextField" name="cam_baseline">
+          <Properties>
+            <Property name="cursor" type="java.awt.Cursor" editor="org.netbeans.modules.form.editors2.CursorEditor">
+              <Color id="Text Cursor"/>
+            </Property>
+            <Property name="minimumSize" type="java.awt.Dimension" editor="org.netbeans.beaninfo.editors.DimensionEditor">
+              <Dimension value="[120, 20]"/>
+            </Property>
+            <Property name="text" type="java.lang.String" value="100"/>
+          </Properties>
+          <AccessibilityProperties>
+            <Property name="AccessibleContext.accessibleName" type="java.lang.String" value=""/>
+          </AccessibilityProperties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="cam_baselineActionPerformed"/>
+          </Events>
+        </Component>
+        <Component class="java.awt.Label" name="label49">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="Baseline"/>
           </Properties>
         </Component>
       </SubComponents>

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
@@ -321,37 +321,37 @@
         </Component>
         <Component class="java.awt.Label" name="label2">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Resolution X:"/>
+            <Property name="text" type="java.lang.String" value="Field of view X"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label3">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Resolution Y:"/>
+            <Property name="text" type="java.lang.String" value="Field of view Y"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label5">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Framerate:"/>
+            <Property name="text" type="java.lang.String" value="Frame rate"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label6">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Readout noise:"/>
+            <Property name="text" type="java.lang.String" value="Readout noise"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label7">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Dark current:"/>
+            <Property name="text" type="java.lang.String" value="Dark current"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label8">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Quantum efficiency:"/>
+            <Property name="text" type="java.lang.String" value="Quantum efficiency"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label9">
           <Properties>
-            <Property name="text" type="java.lang.String" value="ADU per electron:"/>
+            <Property name="text" type="java.lang.String" value="ADU per electron"/>
           </Properties>
           <AccessibilityProperties>
             <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="ADU per electron"/>
@@ -359,22 +359,25 @@
         </Component>
         <Component class="java.awt.Label" name="label10">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Pixel size:"/>
+            <Property name="text" type="java.lang.String" value="Pixel size"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label11">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Numerical aperture:"/>
+            <Property name="text" type="java.lang.String" value="Numerical aperture"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label12">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Wavelength:"/>
+            <Property name="text" type="java.lang.String" value="Wavelength"/>
           </Properties>
+          <AccessibilityProperties>
+            <Property name="AccessibleContext.accessibleName" type="java.lang.String" value="Wavelength"/>
+          </AccessibilityProperties>
         </Component>
         <Component class="java.awt.Label" name="label13">
           <Properties>
-            <Property name="text" type="java.lang.String" value="Magnification:"/>
+            <Property name="text" type="java.lang.String" value="Magnification"/>
           </Properties>
         </Component>
         <Component class="java.awt.TextField" name="cam_resX">
@@ -523,7 +526,7 @@
         </Component>
         <Component class="java.awt.Label" name="label18">
           <Properties>
-            <Property name="text" type="java.lang.String" value="e/px/frame"/>
+            <Property name="text" type="java.lang.String" value="e-/px/frame"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label19">
@@ -533,7 +536,7 @@
         </Component>
         <Component class="java.awt.Label" name="label20">
           <Properties>
-            <Property name="text" type="java.lang.String" value="-"/>
+            <Property name="text" type="java.lang.String" value="ADU/e-"/>
           </Properties>
         </Component>
         <Component class="java.awt.Label" name="label21">
@@ -573,7 +576,7 @@
         </Component>
         <Component class="java.awt.Label" name="label25">
           <Properties>
-            <Property name="text" type="java.lang.String" value="EM gain:"/>
+            <Property name="text" type="java.lang.String" value="EM gain"/>
           </Properties>
         </Component>
         <Component class="java.awt.TextField" name="cam_baseline">

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.form
@@ -99,7 +99,11 @@
           <Group type="103" groupAlignment="0" attributes="0">
               <Group type="102" attributes="0">
                   <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" attributes="0">
+                      <Group type="102" alignment="0" attributes="0">
+                          <EmptySpace min="-2" pref="86" max="-2" attributes="0"/>
+                          <Component id="label26" min="-2" pref="111" max="-2" attributes="0"/>
+                      </Group>
+                      <Group type="102" alignment="0" attributes="0">
                           <EmptySpace max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
                               <Component id="label2" alignment="0" min="-2" max="-2" attributes="0"/>
@@ -109,9 +113,45 @@
                               <Component id="label7" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label8" alignment="0" min="-2" max="-2" attributes="0"/>
                               <Component id="label9" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label25" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label49" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label10" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label11" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label12" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="label13" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                           <EmptySpace min="-2" pref="31" max="-2" attributes="0"/>
                           <Group type="103" groupAlignment="0" attributes="0">
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_magnification" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label24" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_wavelength" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label23" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_NA" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label22" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_px_size" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label21" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_baseline" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label51" min="-2" max="-2" attributes="0"/>
+                              </Group>
+                              <Group type="102" attributes="0">
+                                  <Component id="cam_em_gain" min="-2" pref="45" max="-2" attributes="0"/>
+                                  <EmptySpace max="-2" attributes="0"/>
+                                  <Component id="label50" min="-2" max="-2" attributes="0"/>
+                              </Group>
                               <Group type="102" attributes="0">
                                   <Component id="cam_adu_per_electron" min="-2" pref="45" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
@@ -146,56 +186,6 @@
                                   <Component id="cam_resX" min="-2" pref="45" max="-2" attributes="0"/>
                                   <EmptySpace max="-2" attributes="0"/>
                                   <Component id="label14" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                          </Group>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <EmptySpace min="-2" pref="86" max="-2" attributes="0"/>
-                          <Component id="label26" min="-2" pref="111" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="label25" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace min="-2" pref="108" max="-2" attributes="0"/>
-                          <Component id="cam_em_gain" min="-2" pref="45" max="-2" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="0" attributes="0">
-                              <Component id="label10" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="label11" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="label12" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="label13" alignment="0" min="-2" max="-2" attributes="0"/>
-                              <Component id="label49" alignment="0" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <EmptySpace min="-2" pref="10" max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="0" attributes="0">
-                              <Group type="102" alignment="0" attributes="0">
-                                  <EmptySpace min="-2" pref="21" max="-2" attributes="0"/>
-                                  <Group type="103" groupAlignment="0" attributes="0">
-                                      <Group type="102" alignment="0" attributes="0">
-                                          <Component id="cam_wavelength" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label23" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" alignment="0" attributes="0">
-                                          <Component id="cam_NA" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label22" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Group type="102" alignment="0" attributes="0">
-                                          <Component id="cam_px_size" min="-2" pref="45" max="-2" attributes="0"/>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label21" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Component id="cam_baseline" alignment="0" min="-2" pref="45" max="-2" attributes="0"/>
-                                  </Group>
-                              </Group>
-                              <Group type="102" alignment="0" attributes="0">
-                                  <EmptySpace min="-2" pref="20" max="-2" attributes="0"/>
-                                  <Component id="cam_magnification" min="-2" pref="45" max="-2" attributes="0"/>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="label24" min="-2" max="-2" attributes="0"/>
                               </Group>
                           </Group>
                       </Group>
@@ -273,59 +263,52 @@
                           <Component id="cam_adu_per_electron" min="-2" max="-2" attributes="0"/>
                       </Group>
                   </Group>
-                  <Group type="103" groupAlignment="0" attributes="0">
-                      <Group type="102" attributes="0">
-                          <Component id="cam_em_gain" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace pref="12" max="32767" attributes="0"/>
-                      </Group>
-                      <Group type="102" alignment="1" attributes="0">
-                          <EmptySpace max="32767" attributes="0"/>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="1" attributes="0">
+                      <Group type="103" alignment="1" groupAlignment="0" attributes="0">
                           <Component id="label25" min="-2" max="-2" attributes="0"/>
+                          <Component id="cam_em_gain" alignment="0" min="-2" max="-2" attributes="0"/>
                       </Group>
+                      <Component id="label50" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
                       <Component id="cam_baseline" min="-2" max="-2" attributes="0"/>
-                      <Component id="label49" alignment="1" min="-2" max="-2" attributes="0"/>
+                      <Component id="label49" min="-2" max="-2" attributes="0"/>
+                      <Component id="label51" min="-2" max="-2" attributes="0"/>
                   </Group>
-                  <Group type="103" groupAlignment="1" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
-                          <EmptySpace min="7" pref="7" max="-2" attributes="0"/>
-                          <Component id="label10" min="-2" max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Group type="102" alignment="1" attributes="0">
                           <EmptySpace max="-2" attributes="0"/>
-                          <Component id="label11" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="label12" min="-2" max="-2" attributes="0"/>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Component id="label13" min="-2" max="-2" attributes="0"/>
+                          <Component id="label21" min="-2" max="-2" attributes="0"/>
                       </Group>
-                      <Group type="102" alignment="0" attributes="0">
-                          <Group type="103" groupAlignment="1" attributes="0">
-                              <Group type="102" alignment="1" attributes="0">
-                                  <Group type="103" groupAlignment="1" attributes="0">
-                                      <Group type="102" alignment="1" attributes="0">
-                                          <Group type="103" groupAlignment="1" attributes="0">
-                                              <Component id="label21" alignment="1" min="-2" max="-2" attributes="0"/>
-                                              <Component id="cam_px_size" min="-2" max="-2" attributes="0"/>
-                                          </Group>
-                                          <EmptySpace max="-2" attributes="0"/>
-                                          <Component id="label22" min="-2" max="-2" attributes="0"/>
-                                      </Group>
-                                      <Component id="cam_NA" min="-2" max="-2" attributes="0"/>
-                                  </Group>
-                                  <EmptySpace max="-2" attributes="0"/>
-                                  <Component id="label23" min="-2" max="-2" attributes="0"/>
-                              </Group>
-                              <Component id="cam_wavelength" min="-2" max="-2" attributes="0"/>
-                          </Group>
-                          <EmptySpace max="-2" attributes="0"/>
-                          <Group type="103" groupAlignment="1" attributes="0">
-                              <Component id="cam_magnification" min="-2" max="-2" attributes="0"/>
-                              <Component id="label24" min="-2" max="-2" attributes="0"/>
+                      <Group type="102" attributes="0">
+                          <EmptySpace min="10" pref="10" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Component id="label10" alignment="0" min="-2" max="-2" attributes="0"/>
+                              <Component id="cam_px_size" alignment="0" min="-2" max="-2" attributes="0"/>
                           </Group>
                       </Group>
                   </Group>
                   <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="label11" min="-2" max="-2" attributes="0"/>
+                      <Component id="cam_NA" min="-2" max="-2" attributes="0"/>
+                      <Component id="label22" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="label23" min="-2" max="-2" attributes="0"/>
+                      <Component id="label12" min="-2" max="-2" attributes="0"/>
+                      <Component id="cam_wavelength" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace max="-2" attributes="0"/>
+                  <Group type="103" groupAlignment="0" attributes="0">
+                      <Component id="label13" min="-2" max="-2" attributes="0"/>
+                      <Component id="cam_magnification" min="-2" max="-2" attributes="0"/>
+                      <Component id="label24" min="-2" max="-2" attributes="0"/>
+                  </Group>
+                  <EmptySpace pref="81" max="32767" attributes="0"/>
               </Group>
           </Group>
         </DimensionLayout>
@@ -613,6 +596,16 @@
         <Component class="java.awt.Label" name="label49">
           <Properties>
             <Property name="text" type="java.lang.String" value="Baseline"/>
+          </Properties>
+        </Component>
+        <Component class="java.awt.Label" name="label50">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="-"/>
+          </Properties>
+        </Component>
+        <Component class="java.awt.Label" name="label51">
+          <Properties>
+            <Property name="text" type="java.lang.String" value="ADU"/>
           </Properties>
         </Component>
       </SubComponents>

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
@@ -157,6 +157,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
         label25 = new java.awt.Label();
         cam_baseline = new java.awt.TextField();
         label49 = new java.awt.Label();
+        label50 = new java.awt.Label();
+        label51 = new java.awt.Label();
         panel2 = new java.awt.Panel();
         label1 = new java.awt.Label();
         label27 = new java.awt.Label();
@@ -342,12 +344,19 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         label49.setText("Baseline");
 
+        label50.setText("-");
+
+        label51.setText("ADU");
+
         javax.swing.GroupLayout panel1Layout = new javax.swing.GroupLayout(panel1);
         panel1.setLayout(panel1Layout);
         panel1Layout.setHorizontalGroup(
             panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(panel1Layout.createSequentialGroup()
                 .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(panel1Layout.createSequentialGroup()
+                        .addGap(86, 86, 86)
+                        .addComponent(label26, javax.swing.GroupLayout.PREFERRED_SIZE, 111, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(panel1Layout.createSequentialGroup()
                         .addContainerGap()
                         .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -357,9 +366,39 @@ public class InitSettingsFrame extends java.awt.Dialog {
                             .addComponent(label6, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label7, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label8, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(label9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label49, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label10, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label11, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label12, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addGap(31, 31, 31)
                         .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_magnification, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_wavelength, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label23, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_NA, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label22, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_px_size, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_baseline, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label51, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label50, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                             .addGroup(panel1Layout.createSequentialGroup()
                                 .addComponent(cam_adu_per_electron, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
@@ -387,46 +426,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
                             .addGroup(panel1Layout.createSequentialGroup()
                                 .addComponent(cam_resX, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(label14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                    .addGroup(panel1Layout.createSequentialGroup()
-                        .addGap(86, 86, 86)
-                        .addComponent(label26, javax.swing.GroupLayout.PREFERRED_SIZE, 111, javax.swing.GroupLayout.PREFERRED_SIZE))
-                    .addGroup(panel1Layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(108, 108, 108)
-                        .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE))
-                    .addGroup(panel1Layout.createSequentialGroup()
-                        .addContainerGap()
-                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(label10, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label11, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label12, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label49, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                        .addGap(10, 10, 10)
-                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(panel1Layout.createSequentialGroup()
-                                .addGap(21, 21, 21)
-                                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_wavelength, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label23, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_NA, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label22, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_px_size, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addComponent(cam_baseline, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)))
-                            .addGroup(panel1Layout.createSequentialGroup()
-                                .addGap(20, 20, 20)
-                                .addComponent(cam_magnification, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(label24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))))
+                                .addComponent(label14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         panel1Layout.setVerticalGroup(
@@ -483,46 +483,42 @@ public class InitSettingsFrame extends java.awt.Dialog {
                             .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                             .addComponent(label20, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addComponent(cam_adu_per_electron, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
-                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(panel1Layout.createSequentialGroup()
-                        .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 12, Short.MAX_VALUE))
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, panel1Layout.createSequentialGroup()
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                        .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addComponent(label50, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                 .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addComponent(cam_baseline, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(label49, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, panel1Layout.createSequentialGroup()
-                        .addGap(7, 7, 7)
-                        .addComponent(label10, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(label49, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(label51, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, panel1Layout.createSequentialGroup()
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(label11, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(label12, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(label13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, panel1Layout.createSequentialGroup()
-                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addGroup(panel1Layout.createSequentialGroup()
-                                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                            .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                            .addComponent(cam_px_size, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label22, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addComponent(cam_NA, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(label23, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                            .addComponent(cam_wavelength, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addComponent(cam_magnification, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                .addContainerGap())
+                        .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(panel1Layout.createSequentialGroup()
+                        .addGap(10, 10, 10)
+                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(label10, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(cam_px_size, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(label11, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cam_NA, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(label22, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(label23, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(label12, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cam_wavelength, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(label13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(cam_magnification, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(label24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addContainerGap(81, Short.MAX_VALUE))
         );
 
         label9.getAccessibleContext().setAccessibleName("ADU per electron");
@@ -1266,6 +1262,10 @@ public class InitSettingsFrame extends java.awt.Dialog {
         updateControllerSetupPanel();
     }//GEN-LAST:event_cb_controller_setupPopupMenuWillBecomeInvisible
 
+    private void cam_baselineActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cam_baselineActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_cam_baselineActionPerformed
+
     private void cam_em_gainActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cam_em_gainActionPerformed
         // TODO add your handling code here:
     }//GEN-LAST:event_cam_em_gainActionPerformed
@@ -1273,10 +1273,6 @@ public class InitSettingsFrame extends java.awt.Dialog {
     private void cam_adu_per_electronActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cam_adu_per_electronActionPerformed
         // TODO add your handling code here:
     }//GEN-LAST:event_cam_adu_per_electronActionPerformed
-
-    private void cam_baselineActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cam_baselineActionPerformed
-        // TODO add your handling code here:
-    }//GEN-LAST:event_cam_baselineActionPerformed
 
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
@@ -1365,6 +1361,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
     private java.awt.Label label48;
     private java.awt.Label label49;
     private java.awt.Label label5;
+    private java.awt.Label label50;
+    private java.awt.Label label51;
     private java.awt.Label label6;
     private java.awt.Label label7;
     private java.awt.Label label8;

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
@@ -228,27 +228,27 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         label26.setText("Camera settings");
 
-        label2.setText("Resolution X:");
+        label2.setText("Field of view X");
 
-        label3.setText("Resolution Y:");
+        label3.setText("Field of view Y");
 
-        label5.setText("Framerate:");
+        label5.setText("Frame rate");
 
-        label6.setText("Readout noise:");
+        label6.setText("Readout noise");
 
-        label7.setText("Dark current:");
+        label7.setText("Dark current");
 
-        label8.setText("Quantum efficiency:");
+        label8.setText("Quantum efficiency");
 
-        label9.setText("ADU per electron:");
+        label9.setText("ADU per electron");
 
-        label10.setText("Pixel size:");
+        label10.setText("Pixel size");
 
-        label11.setText("Numerical aperture:");
+        label11.setText("Numerical aperture");
 
-        label12.setText("Wavelength:");
+        label12.setText("Wavelength");
 
-        label13.setText("Magnification:");
+        label13.setText("Magnification");
 
         cam_resX.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
         cam_resX.setMinimumSize(new java.awt.Dimension(120, 20));
@@ -307,11 +307,11 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         label17.setText("RMS");
 
-        label18.setText("e/px/frame");
+        label18.setText("e-/px/frame");
 
         label19.setText("-");
 
-        label20.setText("-");
+        label20.setText("ADU/e-");
 
         label21.setText("um");
 
@@ -331,7 +331,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
             }
         });
 
-        label25.setText("EM gain:");
+        label25.setText("EM gain");
 
         cam_baseline.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
         cam_baseline.setMinimumSize(new java.awt.Dimension(120, 20));
@@ -522,6 +522,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
         );
 
         label9.getAccessibleContext().setAccessibleName("ADU per electron");
+        label12.getAccessibleContext().setAccessibleName("Wavelength");
         cam_baseline.getAccessibleContext().setAccessibleName("");
 
         label1.setText("Fluorophores");

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
@@ -155,6 +155,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
         label24 = new java.awt.Label();
         cam_em_gain = new java.awt.TextField();
         label25 = new java.awt.Label();
+        cam_baseline = new java.awt.TextField();
+        label49 = new java.awt.Label();
         panel2 = new java.awt.Panel();
         label1 = new java.awt.Label();
         label27 = new java.awt.Label();
@@ -319,6 +321,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         cam_em_gain.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
         cam_em_gain.setMinimumSize(new java.awt.Dimension(120, 20));
+        cam_em_gain.setName(""); // NOI18N
         cam_em_gain.setText("100");
         cam_em_gain.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -327,6 +330,17 @@ public class InitSettingsFrame extends java.awt.Dialog {
         });
 
         label25.setText("EM gain:");
+
+        cam_baseline.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
+        cam_baseline.setMinimumSize(new java.awt.Dimension(120, 20));
+        cam_baseline.setText("100");
+        cam_baseline.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cam_baselineActionPerformed(evt);
+            }
+        });
+
+        label49.setText("Baseline");
 
         javax.swing.GroupLayout panel1Layout = new javax.swing.GroupLayout(panel1);
         panel1.setLayout(panel1Layout);
@@ -379,12 +393,17 @@ public class InitSettingsFrame extends java.awt.Dialog {
                         .addComponent(label26, javax.swing.GroupLayout.PREFERRED_SIZE, 111, javax.swing.GroupLayout.PREFERRED_SIZE))
                     .addGroup(panel1Layout.createSequentialGroup()
                         .addContainerGap()
+                        .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(108, 108, 108)
+                        .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(panel1Layout.createSequentialGroup()
+                        .addContainerGap()
                         .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(label10, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label11, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label12, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(label49, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addGap(10, 10, 10)
                         .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addGroup(panel1Layout.createSequentialGroup()
@@ -402,7 +421,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
                                         .addComponent(cam_px_size, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                         .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                                    .addComponent(cam_baseline, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)))
                             .addGroup(panel1Layout.createSequentialGroup()
                                 .addGap(20, 20, 20)
                                 .addComponent(cam_magnification, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -471,6 +490,10 @@ public class InitSettingsFrame extends java.awt.Dialog {
                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, panel1Layout.createSequentialGroup()
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                         .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(cam_baseline, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(label49, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                     .addGroup(javax.swing.GroupLayout.Alignment.LEADING, panel1Layout.createSequentialGroup()
                         .addGap(7, 7, 7)
@@ -503,6 +526,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
         );
 
         label9.getAccessibleContext().setAccessibleName("ADU per electron");
+        cam_baseline.getAccessibleContext().setAccessibleName("");
 
         label1.setText("Fluorophores");
 
@@ -1142,6 +1166,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
                     Double.parseDouble(cam_quantum_eff.getText()),
                     Double.parseDouble(cam_adu_per_electron.getText()),
                     Integer.parseInt(cam_em_gain.getText()),
+                    Integer.parseInt(cam_baseline.getText()),
                     1e-6 *  Double.parseDouble(cam_px_size.getText()),
                     Double.parseDouble(cam_NA.getText()),
                     1e-9 *  Double.parseDouble(cam_wavelength.getText()),
@@ -1249,6 +1274,10 @@ public class InitSettingsFrame extends java.awt.Dialog {
         // TODO add your handling code here:
     }//GEN-LAST:event_cam_adu_per_electronActionPerformed
 
+    private void cam_baselineActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cam_baselineActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_cam_baselineActionPerformed
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel analyzer_panel;
@@ -1258,6 +1287,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
     private java.awt.TextField cam_FPS;
     private java.awt.TextField cam_NA;
     private java.awt.TextField cam_adu_per_electron;
+    private java.awt.TextField cam_baseline;
     private java.awt.TextField cam_dark_current;
     private java.awt.TextField cam_em_gain;
     private java.awt.TextField cam_magnification;
@@ -1333,6 +1363,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
     private java.awt.Label label46;
     private java.awt.Label label47;
     private java.awt.Label label48;
+    private java.awt.Label label49;
     private java.awt.Label label5;
     private java.awt.Label label6;
     private java.awt.Label label7;

--- a/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
+++ b/src/ch/epfl/leb/sass/ijplugin/InitSettingsFrame.java
@@ -137,7 +137,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
         cam_readout_noise = new java.awt.TextField();
         cam_dark_current = new java.awt.TextField();
         cam_quantum_eff = new java.awt.TextField();
-        cam_gain = new java.awt.TextField();
+        cam_adu_per_electron = new java.awt.TextField();
         cam_px_size = new java.awt.TextField();
         cam_NA = new java.awt.TextField();
         cam_wavelength = new java.awt.TextField();
@@ -153,6 +153,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
         label22 = new java.awt.Label();
         label23 = new java.awt.Label();
         label24 = new java.awt.Label();
+        cam_em_gain = new java.awt.TextField();
+        label25 = new java.awt.Label();
         panel2 = new java.awt.Panel();
         label1 = new java.awt.Label();
         label27 = new java.awt.Label();
@@ -234,7 +236,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         label8.setText("Quantum efficiency:");
 
-        label9.setText("Gain:");
+        label9.setText("ADU per electron:");
 
         label10.setText("Pixel size:");
 
@@ -268,9 +270,14 @@ public class InitSettingsFrame extends java.awt.Dialog {
         cam_quantum_eff.setMinimumSize(new java.awt.Dimension(120, 20));
         cam_quantum_eff.setText("0.8");
 
-        cam_gain.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
-        cam_gain.setMinimumSize(new java.awt.Dimension(120, 20));
-        cam_gain.setText("6");
+        cam_adu_per_electron.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
+        cam_adu_per_electron.setMinimumSize(new java.awt.Dimension(120, 20));
+        cam_adu_per_electron.setText("6");
+        cam_adu_per_electron.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cam_adu_per_electronActionPerformed(evt);
+            }
+        });
 
         cam_px_size.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
         cam_px_size.setMinimumSize(new java.awt.Dimension(120, 20));
@@ -310,6 +317,17 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         label24.setText("-");
 
+        cam_em_gain.setCursor(new java.awt.Cursor(java.awt.Cursor.TEXT_CURSOR));
+        cam_em_gain.setMinimumSize(new java.awt.Dimension(120, 20));
+        cam_em_gain.setText("100");
+        cam_em_gain.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                cam_em_gainActionPerformed(evt);
+            }
+        });
+
+        label25.setText("EM gain:");
+
         javax.swing.GroupLayout panel1Layout = new javax.swing.GroupLayout(panel1);
         panel1.setLayout(panel1Layout);
         panel1Layout.setHorizontalGroup(
@@ -325,11 +343,48 @@ public class InitSettingsFrame extends java.awt.Dialog {
                             .addComponent(label6, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label7, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label8, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(31, 31, 31)
+                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_adu_per_electron, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label20, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_quantum_eff, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label19, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_dark_current, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label18, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_readout_noise, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label17, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_FPS, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label16, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_resY, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label15, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addGroup(panel1Layout.createSequentialGroup()
+                                .addComponent(cam_resX, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                .addComponent(label14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                    .addGroup(panel1Layout.createSequentialGroup()
+                        .addGap(86, 86, 86)
+                        .addComponent(label26, javax.swing.GroupLayout.PREFERRED_SIZE, 111, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(panel1Layout.createSequentialGroup()
+                        .addContainerGap()
+                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(label10, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label11, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label12, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(label13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(label13, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                         .addGap(10, 10, 10)
                         .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addGroup(panel1Layout.createSequentialGroup()
@@ -347,42 +402,12 @@ public class InitSettingsFrame extends java.awt.Dialog {
                                         .addComponent(cam_px_size, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                         .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_gain, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label20, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_quantum_eff, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label19, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_dark_current, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label18, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_readout_noise, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label17, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_FPS, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label16, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_resY, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label15, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                    .addGroup(panel1Layout.createSequentialGroup()
-                                        .addComponent(cam_resX, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                        .addComponent(label14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                                    .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)))
                             .addGroup(panel1Layout.createSequentialGroup()
                                 .addGap(20, 20, 20)
                                 .addComponent(cam_magnification, javax.swing.GroupLayout.PREFERRED_SIZE, 45, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(label24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                    .addGroup(panel1Layout.createSequentialGroup()
-                        .addGap(86, 86, 86)
-                        .addComponent(label26, javax.swing.GroupLayout.PREFERRED_SIZE, 111, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                                .addComponent(label24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))))
                 .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
         );
         panel1Layout.setVerticalGroup(
@@ -402,8 +427,53 @@ public class InitSettingsFrame extends java.awt.Dialog {
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(label8, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                        .addComponent(label9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                        .addComponent(label9, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                        .addGroup(panel1Layout.createSequentialGroup()
+                            .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                .addGroup(panel1Layout.createSequentialGroup()
+                                    .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                        .addGroup(panel1Layout.createSequentialGroup()
+                                            .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                                .addGroup(panel1Layout.createSequentialGroup()
+                                                    .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                                        .addGroup(panel1Layout.createSequentialGroup()
+                                                            .addComponent(label26, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                            .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                                                .addGroup(panel1Layout.createSequentialGroup()
+                                                                    .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                                                                        .addComponent(label14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addComponent(cam_resX, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                                                        .addComponent(label2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                                    .addComponent(label15, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                                                .addComponent(cam_resY, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                                            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                            .addComponent(label16, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                                        .addComponent(cam_FPS, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                                    .addComponent(label17, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                                .addComponent(cam_readout_noise, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                            .addComponent(label18, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                        .addComponent(cam_dark_current, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                    .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                                    .addComponent(label19, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                .addComponent(cam_quantum_eff, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                            .addComponent(label20, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addComponent(cam_adu_per_electron, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(panel1Layout.createSequentialGroup()
+                        .addComponent(cam_em_gain, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 12, Short.MAX_VALUE))
+                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, panel1Layout.createSequentialGroup()
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(label25, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, panel1Layout.createSequentialGroup()
+                        .addGap(7, 7, 7)
                         .addComponent(label10, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                         .addComponent(label11, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
@@ -417,45 +487,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
                                 .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                                     .addGroup(panel1Layout.createSequentialGroup()
                                         .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                            .addGroup(panel1Layout.createSequentialGroup()
-                                                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                                    .addGroup(panel1Layout.createSequentialGroup()
-                                                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                                            .addGroup(panel1Layout.createSequentialGroup()
-                                                                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                                                    .addGroup(panel1Layout.createSequentialGroup()
-                                                                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                                                            .addGroup(panel1Layout.createSequentialGroup()
-                                                                                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                                                                    .addGroup(panel1Layout.createSequentialGroup()
-                                                                                        .addComponent(label26, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                                                        .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                                                                            .addGroup(panel1Layout.createSequentialGroup()
-                                                                                                .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                                                                                                    .addComponent(label14, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                                                                                    .addComponent(cam_resX, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                                                                                    .addComponent(label2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                                                                .addComponent(label15, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                                            .addComponent(cam_resY, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                                                        .addComponent(label16, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                                    .addComponent(cam_FPS, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                                                .addComponent(label17, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                            .addComponent(cam_readout_noise, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                                        .addComponent(label18, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                    .addComponent(cam_dark_current, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                                .addComponent(label19, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                            .addComponent(cam_quantum_eff, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                        .addComponent(label20, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                    .addComponent(cam_gain, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                                .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                                            .addComponent(label21, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                                             .addComponent(cam_px_size, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                         .addComponent(label22, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
@@ -467,8 +499,10 @@ public class InitSettingsFrame extends java.awt.Dialog {
                         .addGroup(panel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
                             .addComponent(cam_magnification, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                             .addComponent(label24, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                .addContainerGap(javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                .addContainerGap())
         );
+
+        label9.getAccessibleContext().setAccessibleName("ADU per electron");
 
         label1.setText("Fluorophores");
 
@@ -682,8 +716,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
             }
         });
 
-        emitter_choosefile_button.setEnabled(false);
         emitter_choosefile_button.setLabel("Choose file...");
+        emitter_choosefile_button.setEnabled(false);
         emitter_choosefile_button.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 emitter_choosefile_buttonMouseClicked(evt);
@@ -749,8 +783,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         label47.setText("Number:");
 
-        goldbead_number.setEnabled(false);
         goldbead_number.setText("5");
+        goldbead_number.setEnabled(false);
 
         checkbox_background.setLabel("Background");
         checkbox_background.addItemListener(new java.awt.event.ItemListener() {
@@ -759,8 +793,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
             }
         });
 
-        background_choosefile_button.setEnabled(false);
         background_choosefile_button.setLabel("Choose file...");
+        background_choosefile_button.setEnabled(false);
         background_choosefile_button.addMouseListener(new java.awt.event.MouseAdapter() {
             public void mouseClicked(java.awt.event.MouseEvent evt) {
                 background_choosefile_buttonMouseClicked(evt);
@@ -771,8 +805,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
 
         label48.setText("Signal:");
 
-        goldbead_signal.setEnabled(false);
         goldbead_signal.setText("3000");
+        goldbead_signal.setEnabled(false);
 
         javax.swing.GroupLayout panel5Layout = new javax.swing.GroupLayout(panel5);
         panel5.setLayout(panel5Layout);
@@ -825,12 +859,12 @@ public class InitSettingsFrame extends java.awt.Dialog {
         jLabel1.setText("Analyzer:");
 
         cb_analyzer_setup.addPopupMenuListener(new javax.swing.event.PopupMenuListener() {
-            public void popupMenuCanceled(javax.swing.event.PopupMenuEvent evt) {
+            public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent evt) {
             }
             public void popupMenuWillBecomeInvisible(javax.swing.event.PopupMenuEvent evt) {
                 cb_analyzer_setupPopupMenuWillBecomeInvisible(evt);
             }
-            public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent evt) {
+            public void popupMenuCanceled(javax.swing.event.PopupMenuEvent evt) {
             }
         });
 
@@ -878,12 +912,12 @@ public class InitSettingsFrame extends java.awt.Dialog {
         jLabel2.setText("Controller:");
 
         cb_controller_setup.addPopupMenuListener(new javax.swing.event.PopupMenuListener() {
-            public void popupMenuCanceled(javax.swing.event.PopupMenuEvent evt) {
+            public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent evt) {
             }
             public void popupMenuWillBecomeInvisible(javax.swing.event.PopupMenuEvent evt) {
                 cb_controller_setupPopupMenuWillBecomeInvisible(evt);
             }
-            public void popupMenuWillBecomeVisible(javax.swing.event.PopupMenuEvent evt) {
+            public void popupMenuCanceled(javax.swing.event.PopupMenuEvent evt) {
             }
         });
 
@@ -1106,7 +1140,8 @@ public class InitSettingsFrame extends java.awt.Dialog {
                     Double.parseDouble(cam_readout_noise.getText()),
                     Double.parseDouble(cam_dark_current.getText()),
                     Double.parseDouble(cam_quantum_eff.getText()),
-                    Double.parseDouble(cam_gain.getText()),
+                    Double.parseDouble(cam_adu_per_electron.getText()),
+                    Integer.parseInt(cam_em_gain.getText()),
                     1e-6 *  Double.parseDouble(cam_px_size.getText()),
                     Double.parseDouble(cam_NA.getText()),
                     1e-9 *  Double.parseDouble(cam_wavelength.getText()),
@@ -1206,6 +1241,14 @@ public class InitSettingsFrame extends java.awt.Dialog {
         updateControllerSetupPanel();
     }//GEN-LAST:event_cb_controller_setupPopupMenuWillBecomeInvisible
 
+    private void cam_em_gainActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cam_em_gainActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_cam_em_gainActionPerformed
+
+    private void cam_adu_per_electronActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_cam_adu_per_electronActionPerformed
+        // TODO add your handling code here:
+    }//GEN-LAST:event_cam_adu_per_electronActionPerformed
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JPanel analyzer_panel;
@@ -1214,8 +1257,9 @@ public class InitSettingsFrame extends java.awt.Dialog {
     private java.awt.Button button_initialize;
     private java.awt.TextField cam_FPS;
     private java.awt.TextField cam_NA;
+    private java.awt.TextField cam_adu_per_electron;
     private java.awt.TextField cam_dark_current;
-    private java.awt.TextField cam_gain;
+    private java.awt.TextField cam_em_gain;
     private java.awt.TextField cam_magnification;
     private java.awt.TextField cam_px_size;
     private java.awt.TextField cam_quantum_eff;
@@ -1264,6 +1308,7 @@ public class InitSettingsFrame extends java.awt.Dialog {
     private java.awt.Label label22;
     private java.awt.Label label23;
     private java.awt.Label label24;
+    private java.awt.Label label25;
     private java.awt.Label label26;
     private java.awt.Label label27;
     private java.awt.Label label28;

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 Laboratory of Experimental Biophysics
  * Ecole Polytechnique Federale de Lausanne
  * 
- * Author: Marcel Stefko
+ * Author(s): Marcel Stefko, Kyle M. Douglass
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -48,9 +48,16 @@ public class Camera {
     public final double quantum_efficiency;
 
     /**
-     * gain [-]
+     * Conversion factor between camera's analog-to-digital units (ADU) and electrons. [-]
      */
-    public final double gain;
+    public final double ADU_per_electron;
+    
+    /**
+     * Electron multiplication (EM) gain of the camera.
+     * This may be set to zero for sensors without EM gain, such as CMOS
+     * sensors.
+     */
+    public final int EM_gain;
 
     /**
      * physical size of pixel [m]
@@ -78,11 +85,6 @@ public class Camera {
     public final double thermal_noise;
 
     /**
-     * gain multiplied by quantum efficiency
-     */
-    public final double quantum_gain;
-
-    /**
      * digital representation of the FWHM?
      */
     public final double fwhm_digital;
@@ -105,14 +107,15 @@ public class Camera {
      * @param readout_noise readout noise of camera [RMS]
      * @param dark_current dark current [electrons/second/pixel]
      * @param quantum_efficiency quantum efficiency [0.0-1.0]
-     * @param gain gain [-]
+     * @param ADU_per_electron conversion between camera units and electrons [-]
+     * @param EM_gain electron multiplication gain [-]
      * @param pixel_size physical size of pixel [m]
      * @param NA numerical aperture [-]
      * @param wavelength light wavelength [m]
      * @param magnification magnification of camera [-]
      */
     public Camera(int res_x, int res_y, int acq_speed, double readout_noise, double dark_current,
-            double quantum_efficiency, double gain, double pixel_size, double NA,
+            double quantum_efficiency, double ADU_per_electron, int EM_gain, double pixel_size, double NA,
             double wavelength, double magnification) {
         this.res_x = res_x;
         this.res_y = res_y;
@@ -120,14 +123,14 @@ public class Camera {
         this.readout_noise = readout_noise;
         this.dark_current = dark_current;
         this.quantum_efficiency = quantum_efficiency;
-        this.gain = gain;
+        this.ADU_per_electron = ADU_per_electron;
+        this.EM_gain = EM_gain;
         this.pixel_size = pixel_size;
         this.NA = NA;
         this.wavelength = wavelength;
         this.magnification = magnification;
         
         this.thermal_noise = this.dark_current / this.acq_speed;
-        this.quantum_gain = this.quantum_efficiency * this.gain;
         
         // calculate Gaussian PSF
         double airy_psf_radius = 0.61*wavelength/NA;

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Camera.java
@@ -60,6 +60,11 @@ public class Camera {
     public final int EM_gain;
 
     /**
+     * Camera pixel baseline (zero signal mean) [ADU]
+     */
+    public final int baseline;
+    
+    /**
      * physical size of pixel [m]
      */
     public final double pixel_size;
@@ -109,14 +114,17 @@ public class Camera {
      * @param quantum_efficiency quantum efficiency [0.0-1.0]
      * @param ADU_per_electron conversion between camera units and electrons [-]
      * @param EM_gain electron multiplication gain [-]
+     * @param baseline zero-signal average of pixel values [ADU]
      * @param pixel_size physical size of pixel [m]
      * @param NA numerical aperture [-]
      * @param wavelength light wavelength [m]
      * @param magnification magnification of camera [-]
      */
-    public Camera(int res_x, int res_y, int acq_speed, double readout_noise, double dark_current,
-            double quantum_efficiency, double ADU_per_electron, int EM_gain, double pixel_size, double NA,
-            double wavelength, double magnification) {
+    public Camera(int res_x, int res_y, int acq_speed, double readout_noise,
+            double dark_current, double quantum_efficiency,
+            double ADU_per_electron, int EM_gain, int baseline,
+            double pixel_size, double NA, double wavelength,
+            double magnification) {
         this.res_x = res_x;
         this.res_y = res_y;
         this.acq_speed = acq_speed;
@@ -125,6 +133,7 @@ public class Camera {
         this.quantum_efficiency = quantum_efficiency;
         this.ADU_per_electron = ADU_per_electron;
         this.EM_gain = EM_gain;
+        this.baseline = baseline;
         this.pixel_size = pixel_size;
         this.NA = NA;
         this.wavelength = wavelength;

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/Device.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/Device.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 Laboratory of Experimental Biophysics
  * Ecole Polytechnique Federale de Lausanne
  * 
- * Author: Marcel Stefko
+ * Author(s): Marcel Stefko, Kyle M. Douglass
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -57,9 +57,10 @@ public class Device {
                             400, //res_y
                             100, //acq_speed, 
                             1.6, //readout_noise, 
-                            0.06, //dark_current, 
-                            0.8, //quantum_efficiency, 
-                            6, //gain, 
+                            0.06,//dark_current, 
+                            0.9, //quantum_efficiency, 
+                            45, //ADU_per_electron,
+                            300, // EM_gain
                             6.45 * 1e-6, //pixel_size, 
                             1.3, //NA, 
                             600 * 1e-9, //wavelength, 
@@ -215,7 +216,7 @@ public class Device {
     }
     
     /**
-     * Adds Poisson, readout, thermal and quantum gain noise to the image.
+     * Adds Poisson,  readout,  thermal, and electron multiplication  noise to the image.
      * @param image image to be noised up
      */
     private void addNoises(float[][] image) {
@@ -233,8 +234,8 @@ public class Device {
         for (int row=0; row < image.length; row++) {
             for (int col=0; col < image[row].length; col++) {
                 image[row][col] += camera.readout_noise*gaussian.nextDouble() +
-                                   camera.thermal_noise*gaussian.nextDouble() +
-                                   gamma.nextDouble(image[row][col]+0.01f,camera.quantum_gain); //0.01f so that we dont do nextDouble(0,c)
+                                   camera.thermal_noise*gaussian.nextDouble();
+                                   //gamma.nextDouble(image[row][col]+0.01f,camera.quantum_gain); //0.01f so that we dont do nextDouble(0,c)
             }
         }
     }

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/STORMsim.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/STORMsim.java
@@ -2,7 +2,7 @@
  * Copyright (C) 2017 Laboratory of Experimental Biophysics
  * Ecole Polytechnique Federale de Lausanne
  * 
- * Author: Marcel Stefko
+ * Author(s): Marcel Stefko, Kyle M. Douglass
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -125,7 +125,8 @@ public class STORMsim extends AbstractGenerator {
                             gd.getNextNumber(), //readout_noise, 
                             gd.getNextNumber(), //dark_current, 
                             gd.getNextNumber(), //quantum_efficiency, 
-                            gd.getNextNumber(), //gain, 
+                            gd.getNextNumber(), //ADU_per_electron,
+                            (int)gd.getNextNumber(), // EM_gain)
                             gd.getNextNumber() * 1e-6, //pixel_size, 
                             gd.getNextNumber(), //NA, 
                             gd.getNextNumber() * 1e-9, //wavelength, 

--- a/src/ch/epfl/leb/sass/simulator/generators/realtime/STORMsim.java
+++ b/src/ch/epfl/leb/sass/simulator/generators/realtime/STORMsim.java
@@ -112,7 +112,9 @@ public class STORMsim extends AbstractGenerator {
         gd.addNumericField("Readout noise [rms]", 1.6, 1);
         gd.addNumericField("Dark current [e/px/frame]",0.06,3);
         gd.addNumericField("Quantum efficiency", 0.8, 2);
-        gd.addNumericField("Gain", 6, 1);
+        gd.addNumericField("ADU per electron", 0.0200, 4);
+        gd.addNumericField("EM gain", 100, 0);
+        gd.addNumericField("Baseline", 100, 0);
         gd.addNumericField("Pixel size [um]", 6.45, 3);
         gd.addNumericField("Numerical aperture", 1.3, 2);
         gd.addNumericField("Wavelength [nm]", 600, 0);
@@ -126,7 +128,8 @@ public class STORMsim extends AbstractGenerator {
                             gd.getNextNumber(), //dark_current, 
                             gd.getNextNumber(), //quantum_efficiency, 
                             gd.getNextNumber(), //ADU_per_electron,
-                            (int)gd.getNextNumber(), // EM_gain)
+                            (int)gd.getNextNumber(), // EM_gain,
+                            (int)gd.getNextNumber(), // baseline,
                             gd.getNextNumber() * 1e-6, //pixel_size, 
                             gd.getNextNumber(), //NA, 
                             gd.getNextNumber() * 1e-9, //wavelength, 


### PR DESCRIPTION
### Added
- Electron multiplication (EM) gain and camera baseline parameters.

### Fixed
- The camera noise model was improperly accounting for electron multiplication noise. This is now fixed so that the simulation encompasses both EMCCD's (by setting the EM gain to a non-zero value) and sCMOS (by setting the EM gain to zero.)